### PR TITLE
fix: withdraw recipientAta

### DIFF
--- a/subgraph/src/handlers/index.ts
+++ b/subgraph/src/handlers/index.ts
@@ -244,7 +244,7 @@ export function handleWithdraw(event: EventWithdraw, system: ProtoData): void {
   }
 
   if (stream.recipientAta == null) {
-    stream.recipient = event.recipientAta;
+    stream.recipientAta = event.recipientAta;
   }
 
   stream.save();
@@ -295,7 +295,7 @@ export function handleWithdrawMax(
   }
 
   if (stream.recipientAta == null) {
-    stream.recipient = event.recipientAta;
+    stream.recipientAta = event.recipientAta;
   }
 
   stream.save();


### PR DESCRIPTION
This PR fixes the withdrawal bug. It has already been deployed to [Graph](https://thegraph.com/studio/subgraph/sablier-solana-lockup-experimental-2/) as `v0.0.3` and has been tested on the FE.

**Bug 🐛**
<img src="https://github.com/user-attachments/assets/a626542c-aeb0-46c2-bbf8-942c3c64fd7e" alt="x 2" width="300"/>
