### PR TITLE
feat: add asset decimals

### DIFF
--- a/proto/program.proto
+++ b/proto/program.proto
@@ -29,7 +29,7 @@ message Cancel {
 
     string treasury = 9;
     string treasury_ata = 10;
- 
+
     uint64 stream_id = 11;
     string nft_mint = 12;
     string nft_data = 13;
@@ -39,7 +39,7 @@ message CreateWithTimestamps {
     string instruction_program = 1;
     uint64 instruction_index = 2;
     string transaction_hash = 3;
-   
+
     int64 start_time = 4;
     int64 cliff_time = 5;
     int64 end_time = 6;
@@ -53,7 +53,7 @@ message CreateWithTimestamps {
     string sender = 11;
     string sender_ata = 12;
     string recipient = 13;
-    
+
     string token_mint = 14;
     string token_program = 15;
 
@@ -65,6 +65,7 @@ message CreateWithTimestamps {
     string nft_data = 20;
     string nft_recipient_ata = 21;
 
+    uint32 token_decimals = 22;
 }
 
 message Renounce {
@@ -115,9 +116,8 @@ message Withdraw {
     string nft_data = 13;
 
     string signer = 14;
-
-
 }
+
 message WithdrawMax {
     string instruction_program = 1;
     uint64 instruction_index = 2;
@@ -140,4 +140,3 @@ message WithdrawMax {
 
     string signer = 14;
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,11 +61,13 @@ fn handle_create_with_timestamps(index: usize, instruction: &InstructionView) ->
         let logs = util::get_anchor_logs(instruction);
 
         let mut stream_id = 0;
+        let mut token_decimals = 0;
 
         for log in logs {
             if log[0..8] == lockup_linear_v10_events::StreamCreation::DISCRIMINATOR {
                 if let Ok(event) = lockup_linear_v10_events::StreamCreation::deserialize(&mut &log[8..]) {
                     stream_id = event.stream_id;
+                    token_decimals = event.asset_decimals;
                 }
             }
         }
@@ -84,6 +86,7 @@ fn handle_create_with_timestamps(index: usize, instruction: &InstructionView) ->
             cancelable: arguments.is_cancelable,
 
             stream_id,
+            token_decimals: token_decimals as u32,
 
             sender: accounts[0].to_string(),
             token_mint: accounts[1].to_string(),

--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -71,6 +71,9 @@ type Asset @entity(immutable: true) {
   "token program (manager) address of the asset/token"
   program: String!
 
+  "decimals of the asset/token"
+  decimals: BigInt!
+
   "streams that rely on this asset/token"
   streams: [Stream!]! @derivedFrom(field: "asset")
 }

--- a/subgraph/src/helpers/asset.ts
+++ b/subgraph/src/helpers/asset.ts
@@ -2,7 +2,7 @@ import { BigInt } from "@graphprotocol/graph-ts";
 import { Asset } from "../../generated/schema";
 import { getChainId, getChainCode, getCluster } from "../constants";
 
-export function getOrCreateAsset(mint: string, program: string): Asset {
+export function getOrCreateAsset(mint: string, program: string, decimals: u32): Asset {
   let id = generateAssetId(mint);
 
   let entity = Asset.load(id);
@@ -16,6 +16,7 @@ export function getOrCreateAsset(mint: string, program: string): Asset {
     entity.address = mint;
     entity.mint = mint;
     entity.program = program;
+    entity.decimals = BigInt.fromU32(decimals);
 
     entity.save();
   }

--- a/subgraph/src/helpers/stream.ts
+++ b/subgraph/src/helpers/stream.ts
@@ -129,7 +129,7 @@ export function createLinearStream(
   }
 
   /** --------------- */
-  let asset = getOrCreateAsset(event.tokenMint, event.tokenProgram);
+  let asset = getOrCreateAsset(event.tokenMint, event.tokenProgram, event.tokenDecimals);
   entity.asset = asset.id;
 
   return entity;


### PR DESCRIPTION
This PR adds support for asset decimals based on the emitted event. Deployed as [v.0.0.4](https://thegraph.com/studio/subgraph/sablier-solana-lockup-experimental-2/).
